### PR TITLE
Restore DP functionality in FixNVESpin

### DIFF
--- a/SPIN_swd/fix_nve_spin.h
+++ b/SPIN_swd/fix_nve_spin.h
@@ -41,6 +41,7 @@ class FixNVESpin : public Fix {
   void AdvanceSingleSpin(int);
   void AdvanceSingleSpin_no_langevin(int, double *, double *);
   void AdvanceSingleSpin_one_side(int, double *, double *);
+  void ComputeForceDP(int, int);
   //
   
   void sectoring();    // sectoring operation functions
@@ -90,6 +91,7 @@ class FixNVESpin : public Fix {
 
   // sectoring variables
 
+  double cutoff_dp;
   int nsectors;
   double *rsec;
 


### PR DESCRIPTION
## Summary
- add `cutoff_dp` and `ComputeForceDP` prototypes to `FixNVESpin`
- parse `cutoff` argument and store in `cutoff_dp`
- reintroduce `ComputeForceDP` method
- call DP force computation during spin integration
- allow sectoring to use `cutoff_dp` when provided

## Testing
- `make` *(fails: No targets specified)*

------
https://chatgpt.com/codex/tasks/task_e_686b35bd35a0832696e72c99dc2e60e2